### PR TITLE
jayeskay/AWS-18: Fix bypassed commitlint rule

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
   "commitlint": {
     "rules": {
       "references-empty": [2, "never"],
+      "type-empty": [2, "never"],
       "type-enum": [
         2,
         "always",


### PR DESCRIPTION
Include `"type-empty"` rule to also **require** commit keyword from `"type-enum"` list, rather than pass if issue ID is specified.

Resolves #19